### PR TITLE
support extra header to use class component

### DIFF
--- a/index.js
+++ b/index.js
@@ -321,7 +321,7 @@ export const withCollapsible = (WrappedScreen, collapsibleParams = {}) => {
           {!collapsibleParams.extraHeader 
             ? <CollapsibleHeaderBackView iOSCollapsedColor={collapsibleParams.iOSCollapsedColor} navigation={navigation} />
             : (<CollapsibleExtraHeader headerY={this.headerY} style={collapsibleParams.extraHeaderStyle}>
-              {collapsibleParams.extraHeader(props)}
+                <collapsibleParams.extraHeader {...props}/>
               </CollapsibleExtraHeader>)
           }
         </View>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-navigation-collapsible",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "React Navigation Extension for Collapsible Header",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
#13 
it's working only with the stateless component.
Now it supports extra header to use class component. 