### PR TITLE
React navigation 3.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 import React, {Component} from 'react';
 import { Animated, Platform, Dimensions, View } from 'react-native';
-import withOrientation, {isOrientationLandscape} from 'react-navigation/src/views/withOrientation';
+import { withOrientation, isOrientationLandscape } from '@react-navigation/native';
 import hoistNonReactStatic from 'hoist-non-react-statics';
 import SafeAreaView from 'react-native-safe-area-view';
 


### PR DESCRIPTION
React navigation has updated its project structure.
These utils now need to be imported from   '@react-navigation/native';