### PR TITLE
make useNativeDriver configurable

### DIFF
--- a/src/createCollapsibleStack.tsx
+++ b/src/createCollapsibleStack.tsx
@@ -38,14 +38,16 @@ const createCollapsibleStack = (
   const onScroll = Animated.event(
     [{ nativeEvent: { contentOffset: { y: positionY } } }],
     {
-      useNativeDriver: true,
+      useNativeDriver:
+        config.useNativeDriver === undefined ? true : config.useNativeDriver,
     }
   );
   const onScrollWithListener = (
     listener: (event: NativeSyntheticEvent<NativeScrollEvent>) => void
   ) =>
     Animated.event([{ nativeEvent: { contentOffset: { y: positionY } } }], {
-      useNativeDriver: true,
+      useNativeDriver:
+        config.useNativeDriver === undefined ? true : config.useNativeDriver,
       listener,
     });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,4 +18,5 @@ export type Collapsible = {
 
 export type CollapsibleStackConfig = {
   collapsedColor?: string;
+  useNativeDriver?: boolean;
 };


### PR DESCRIPTION
For the use with [react-native-swipe-list-view](https://github.com/jemise111/react-native-swipe-list-view) I had to disable `useNativeDriver` in order to make it work ([here's the reason why](https://stackoverflow.com/a/57402978)).

Therefore I thought it would be useful to make this property configurable in the `CollapsibleStack` options.