### PR TITLE
fixes #134 by setting safeBounceHeight for web as well

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,10 +5,12 @@ import { isIphoneX } from 'react-native-iphone-x-helper';
 
 const SAFEBOUNCE_HEIGHT_IOS = 300;
 const SAFEBOUNCE_HEIGHT_ANDROID = 100;
+const SAFEBOUNCE_HEIGHT_WEB = 0;
 
 let safeBounceHeight = Platform.select({
   ios: SAFEBOUNCE_HEIGHT_IOS,
   android: SAFEBOUNCE_HEIGHT_ANDROID,
+  web: SAFEBOUNCE_HEIGHT_WEB,
 });
 
 const setSafeBounceHeight = (height: number) => {


### PR DESCRIPTION
I ran into [this issue](https://github.com/benevbright/react-navigation-collapsible/issues/114) on web, where it raises an invariant violation when one of the `inputRange` numbers is `undefined` (in this case the `safeBounceHeight`)

I wasn't sure what a sensible `safeBounceHeight` would be for web, so I was hoping you could advise me on that.