### PR TITLE
Show the header programatically when requested

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -16,6 +16,7 @@ import {
   renderCustomHeader,
 } from './src/CustomHeaderScreen';
 import { DetailScreen } from './src/DetailScreen';
+import { ShowHeaderScreen } from './src/ShowHeaderScreen';
 
 export type StackParamList = {
   Home: undefined;
@@ -26,6 +27,7 @@ export type StackParamList = {
   SubHeader: undefined;
   WithCustomHeader: undefined;
   CustomHeaderDetail: undefined;
+  ShowHeaderScreen: undefined;
 };
 
 type ScreenProps = {
@@ -38,6 +40,7 @@ const samples: { title: string; routeName: keyof StackParamList }[] = [
   { title: 'Sample 1-3: Background Header', routeName: 'BackgroundHeader' },
   { title: 'Sample 2: Sub Header', routeName: 'SubHeader' },
   { title: 'Sample 3: Custom Header', routeName: 'WithCustomHeader' },
+  { title: 'Sample 4: Show Header Manually', routeName: 'ShowHeaderScreen' },
 ];
 
 function HomeScreen({ navigation }: ScreenProps) {
@@ -141,6 +144,15 @@ function App() {
           options={{
             title: 'Detail Screen',
             header: renderCustomHeader,
+          }}
+        />
+
+        <Stack.Screen
+          name="ShowHeaderScreen"
+          component={ShowHeaderScreen}
+          options={{
+            headerTintColor: 'white',
+            title: 'Default Header',
           }}
         />
       </Stack.Navigator>

--- a/example/src/ShowHeaderScreen.tsx
+++ b/example/src/ShowHeaderScreen.tsx
@@ -21,7 +21,7 @@ const ShowHeaderScreen = ({ navigation }: ScreenProps) => {
     // onScrollWithListener,
     containerPaddingTop,
     scrollIndicatorInsetTop,
-    showHeader
+    showHeader,
   } = useCollapsibleHeader({
     navigationOptions: {
       headerStyle: {
@@ -49,18 +49,21 @@ const ShowHeaderScreen = ({ navigation }: ScreenProps) => {
       scrollIndicatorInsets={{ top: scrollIndicatorInsetTop }}
       renderItem={({ item, index }: any) => {
         if (index === 10 || index === 50 || index === 70) {
-          return <View style={{
-              width: '100%',
-              height: 50,
-              alignItems: 'center',
-              justifyContent: 'center',
-              borderBottomColor: 'gray',
-              borderBottomWidth: 1,
-          }}>
-            <Button title="Show Header" onPress={showHeader}/>
-          </View>
+          return (
+            <View
+              style={{
+                width: '100%',
+                height: 50,
+                alignItems: 'center',
+                justifyContent: 'center',
+                borderBottomColor: 'gray',
+                borderBottomWidth: 1,
+              }}>
+              <Button title="Show Header" onPress={showHeader} />
+            </View>
+          );
         }
-        return createRow(() => navigation.navigate('Detail'))({item});
+        return createRow(() => navigation.navigate('Detail'))({ item });
       }}
       keyExtractor={(item: any) => item.toString()}
     />

--- a/example/src/ShowHeaderScreen.tsx
+++ b/example/src/ShowHeaderScreen.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { Animated, Button, View } from 'react-native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { useCollapsibleHeader } from 'react-navigation-collapsible';
+
+import { StackParamList } from '../App';
+import { createRow } from './Row';
+
+const data: number[] = [];
+for (let i = 0; i < 100; i++) {
+  data.push(i);
+}
+
+type ScreenProps = {
+  navigation: StackNavigationProp<StackParamList>;
+};
+
+const ShowHeaderScreen = ({ navigation }: ScreenProps) => {
+  const {
+    onScroll,
+    // onScrollWithListener,
+    containerPaddingTop,
+    scrollIndicatorInsetTop,
+    showHeader
+  } = useCollapsibleHeader({
+    navigationOptions: {
+      headerStyle: {
+        backgroundColor: 'green',
+        // height: 150,
+      },
+    },
+    config: {
+      collapsedColor: 'red',
+    },
+  });
+
+  /* in case you want to use your listener
+  const listener = ({nativeEvent}) => {
+    console.log(nativeEvent);
+  };
+  const onScroll = onScrollWithListener(listener);
+  */
+
+  return (
+    <Animated.FlatList
+      data={data}
+      onScroll={onScroll}
+      contentContainerStyle={{ paddingTop: containerPaddingTop }}
+      scrollIndicatorInsets={{ top: scrollIndicatorInsetTop }}
+      renderItem={({ item, index }: any) => {
+        if (index === 10 || index === 50 || index === 70) {
+          return <View style={{
+              width: '100%',
+              height: 50,
+              alignItems: 'center',
+              justifyContent: 'center',
+              borderBottomColor: 'gray',
+              borderBottomWidth: 1,
+          }}>
+            <Button title="Show Header" onPress={showHeader}/>
+          </View>
+        }
+        return createRow(() => navigation.navigate('Detail'))({item});
+      }}
+      keyExtractor={(item: any) => item.toString()}
+    />
+  );
+};
+
+export { ShowHeaderScreen };

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@types/react": "^16.9.50",
-    "@types/react-native": "^0.63.25",
+    "@types/react-native": "0.63.25",
     "@typescript-eslint/eslint-plugin": "^2.13.0",
     "@typescript-eslint/parser": "^2.13.0",
     "eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@types/react": "^16.9.50",
-    "@types/react-native": "^0.63.23",
+    "@types/react-native": "^0.63.25",
     "@typescript-eslint/eslint-plugin": "^2.13.0",
     "@typescript-eslint/parser": "^2.13.0",
     "eslint": "^6.8.0",

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -34,6 +34,7 @@ export type Collapsible = {
   translateY: Animated.AnimatedInterpolation;
   progress: Animated.AnimatedInterpolation;
   opacity: Animated.AnimatedInterpolation;
+  showHeader: () => void;
 };
 
 export type UseCollapsibleOptions = {
@@ -93,6 +94,12 @@ const useCollapsibleHeader = (
     // @ts-ignore
     collapsibleCustomHeaderHeight: customHeaderHeight,
   } = route.params || {};
+
+  const showHeader = () => {
+      positionY.setValue(0);
+      // Forces to show the header again
+      setHeaderStyle({...headerStyle});
+  }
 
   React.useLayoutEffect(() => {
     let headerHeight = 0;
@@ -163,6 +170,7 @@ const useCollapsibleHeader = (
       translateY,
       progress,
       opacity,
+      showHeader
     };
     setCollapsible(collapsible);
   }, [isLandscape, headerStyle, subHeaderHeight, customHeaderHeight]);
@@ -176,6 +184,7 @@ const useCollapsibleHeader = (
       translateY: new Animated.Value(0),
       progress: new Animated.Value(0),
       opacity: new Animated.Value(1),
+      showHeader
     }
   );
 };

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -96,10 +96,10 @@ const useCollapsibleHeader = (
   } = route.params || {};
 
   const showHeader = () => {
-      positionY.setValue(0);
-      // Forces to show the header again
-      setHeaderStyle({...headerStyle});
-  }
+    positionY.setValue(0);
+    // Forces to show the header again
+    setHeaderStyle({ ...headerStyle });
+  };
 
   React.useLayoutEffect(() => {
     let headerHeight = 0;
@@ -170,7 +170,7 @@ const useCollapsibleHeader = (
       translateY,
       progress,
       opacity,
-      showHeader
+      showHeader,
     };
     setCollapsible(collapsible);
   }, [isLandscape, headerStyle, subHeaderHeight, customHeaderHeight]);
@@ -184,7 +184,7 @@ const useCollapsibleHeader = (
       translateY: new Animated.Value(0),
       progress: new Animated.Value(0),
       opacity: new Animated.Value(1),
-      showHeader
+      showHeader,
     }
   );
 };

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -97,8 +97,6 @@ const useCollapsibleHeader = (
 
   const showHeader = () => {
     positionY.setValue(0);
-    // Forces to show the header again
-    setHeaderStyle({ ...headerStyle });
   };
 
   React.useLayoutEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,10 +33,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/react-native@^0.63.23":
-  version "0.63.23"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.23.tgz#bc4617e5bbb1ac28cb5dbf7ad09cc49a2cce914c"
-  integrity sha512-4pWQpgyzX+vCEJDceW9Zsc8/SZtJrIUIw9lwYKeTWAtSHWdcRwUns2O/18L98WGo6NUNVdLzY59vOW8ZGWJxSA==
+"@types/react-native@^0.63.25":
+  version "0.63.30"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.63.30.tgz#a0bd61e61b7a020a538ea22901be2f5d178fe02f"
+  integrity sha512-8/PrOjuUaPTCfMeW12ubseZPUGdbRhxYDa/aT+0D0KWVTe60b4H/gJrcfJmBXC6EcCFcimuTzQCv8/S03slYqA==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
This PR exposes a new method in the library called "showHeader" when you call this method the header will be shown again as at the beginning , this is very useful for the following situations:

 - The app rotates and you want to show the header again.
 - There are situation where the user scrolls really slowly to the bottom of the screen and the header looks halfway through, with this you can detect if you reach the bottom of a scrollview and then show it again.

This PR has been created in response to this issue created a few days ago https://github.com/benevbright/react-navigation-collapsible/issues/161

Let me know if you need me to do anything else @benevbright 


Also it would be possible to do the hide (pretty simple) but for our requirements is enough with show, but if you need my help I can create another PR for the hide.