### PR TITLE
Add header types for useCollapsibleOptions

### DIFF
--- a/src/core.tsx
+++ b/src/core.tsx
@@ -38,7 +38,7 @@ export type Collapsible = {
 };
 
 export type UseCollapsibleOptions = {
-  navigationOptions?: { [key: string]: any };
+  navigationOptions?: { header?: (props: StackHeaderProps) => React.ReactNode; [key: string]: any; };
   config?: {
     useNativeDriver?: boolean;
     elevation?: number;


### PR DESCRIPTION
Add `StackHeaderProps` to `header` field in `useCollapsibleOptions`.