### PR TITLE
refactor: return positionY from the hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ const MyScreen = ({ navigation, route }) => {
     onScrollWithListener /* Event handler creator */,
     containerPaddingTop /* number */,
     scrollIndicatorInsetTop /* number */,
-    /* Animated.AnimatedInterpolation by scrolling */
+    /* Animated.AnimatedValue contentOffset from scrolling */
+    positionY /* 0.0 ~ length of scrollable component (contentOffset)
+    /* Animated.AnimatedInterpolation by scrolling */,
     translateY /* 0.0 ~ -headerHeight */,
     progress /* 0.0 ~ 1.0 */,
     opacity /* 1.0 ~ 0.0 */,

--- a/src/core.tsx
+++ b/src/core.tsx
@@ -31,6 +31,7 @@ export type Collapsible = {
   ) => (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
   containerPaddingTop: number;
   scrollIndicatorInsetTop: number;
+  positionY: Animated.AnimatedValue;
   translateY: Animated.AnimatedInterpolation;
   progress: Animated.AnimatedInterpolation;
   opacity: Animated.AnimatedInterpolation;
@@ -165,6 +166,7 @@ const useCollapsibleHeader = (
           ? headerHeight
           : getNavigationHeight(isLandscape, headerHeight),
       scrollIndicatorInsetTop: headerHeight,
+      positionY,
       translateY,
       progress,
       opacity,
@@ -179,6 +181,7 @@ const useCollapsibleHeader = (
       onScrollWithListener: e => null,
       containerPaddingTop: 0,
       scrollIndicatorInsetTop: 0,
+      positionY: new Animated.Value(0),
       translateY: new Animated.Value(0),
       progress: new Animated.Value(0),
       opacity: new Animated.Value(1),


### PR DESCRIPTION
Thanks for an awesome lib, it have helped me a lot in my projects!

But I have a scenario where I need the `positionY` in my component in order to do more animations and interpolations based on the `contentOffset` of the scroll view. This PR adds `positionY` to the `Collapsible` type and adds it to the returned object it in the hook.

Please let me know if I should do any changes or additions. Thank you!