### PR TITLE
Fix react-navigation v6 custom header

### DIFF
--- a/example/src/CustomHeaderScreen.tsx
+++ b/example/src/CustomHeaderScreen.tsx
@@ -16,17 +16,12 @@ type ScreenProps = {
 };
 
 export const renderCustomHeader = ({
-  scene,
-  previous,
   navigation,
+  options,
+  route,
+  progress,
 }: StackHeaderProps) => {
-  const { options } = scene.descriptor;
-  const title =
-    options.headerTitle !== undefined
-      ? options.headerTitle
-      : options.title !== undefined
-      ? options.title
-      : scene.route.name;
+  const title = options.headerTitle || options.title || route.name;
 
   return (
     <View
@@ -52,7 +47,7 @@ export const renderCustomHeader = ({
           {title}
         </Text>
 
-        {previous && (
+        {progress?.previous && (
           <TouchableOpacity onPress={navigation.goBack}>
             <View>
               <Text

--- a/src/createCollapsibleCustomHeaderAnimator.tsx
+++ b/src/createCollapsibleCustomHeaderAnimator.tsx
@@ -8,7 +8,7 @@ export const createCollapsibleCustomHeaderAnimator = (
   customHeader: CustomHeader
 ) => (headerProps: StackHeaderProps) => (
   <Animated.View
-    style={headerProps?.scene?.descriptor?.options?.headerStyle}
+    style={headerProps?.options?.headerStyle}
     onLayout={(e: LayoutChangeEvent) => {
       headerProps.navigation.setParams({
         collapsibleCustomHeaderHeight: e.nativeEvent.layout.height,


### PR DESCRIPTION
There are breaking changes in the custom header.
https://reactnavigation.org/docs/upgrading-from-5.x#props-passed-to-custom-header-are-streamlined